### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ pre-installed, the system Vim might be too old (see `vim --version`).
 This plugin supports Windows, macOS, and Linux.
 
 In addition to Neovim or Vim, vim-markdown-composer requires a distribution of
-[Rust] with `cargo`. To easily install the lastest version of Rust with `cargo`,
-check out [rustup.rs](https://www.rustup.rs/).
+[Rust] with `cargo`. Check out the [Rust installation guide].
 
 vim-markdown-composer officially targets the latest version of [stable Rust].
 
@@ -28,6 +27,8 @@ vim-markdown-composer officially targets the latest version of [stable Rust].
 
 Use whatever plugin manager you like. If you aren't familiar with plugin
 managers, I recommend [vim-plug].
+
+### vim-plug
 
 Here's an an example of managing installation with vim-plug:
 
@@ -44,6 +45,26 @@ endfunction
 
 Plug 'euclio/vim-markdown-composer', { 'do': function('BuildComposer') }
 ```
+
+### Vundle
+
+In your `.vimrc`:
+
+```vim
+Plugin 'euclio/vim-markdown-composer'
+```
+
+Once you have installed the plugin, close Vim/Neovim then (on Linux):
+
+```sh
+$ cd ~/.vim/bundle/vim-markdown-composer/
+# Vim
+$ cargo build --release --no-default-features --features json-rpc
+# Neovim
+$ cargo build --release
+```
+
+### Other plugin managers
 
 You should run `cargo build --release` in the plugin directory after
 installation. Vim support requires the `json-rpc` cargo feature.
@@ -71,3 +92,4 @@ previews.
 [msgpack-rpc]: https://github.com/msgpack-rpc/msgpack-rpc
 [aurelius]: https://github.com/euclio/aurelius
 [stable Rust]: https://www.rust-lang.org/downloads.html
+[Rust installation guide]: https://www.rust-lang.org/en-US/install.html


### PR DESCRIPTION
Added details for Vundle installation and changed the Rust installation link to go to the official Rust installation page as there are multiple alternate ways of installing Rust.