### PR TITLE
Recommend using --locked for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Here's an example of managing installation with vim-plug:
 function! BuildComposer(info)
   if a:info.status != 'unchanged' || a:info.force
     if has('nvim')
-      !cargo build --release
+      !cargo build --release --locked
     else
-      !cargo build --release --no-default-features --features json-rpc
+      !cargo build --release --locked --no-default-features --features json-rpc
     endif
   endif
 endfunction


### PR DESCRIPTION
Will avoid accidental edits to the `Cargo.lock` which will cause git conflicts on update.