### PR TITLE
Add options to fix address and port number which the server will listen on

### DIFF
--- a/after/ftplugin/markdown/composer.vim
+++ b/after/ftplugin/markdown/composer.vim
@@ -33,6 +33,14 @@ function! s:startServer()
     call extend(l:args, ['--external-renderer', g:markdown_composer_external_renderer])
   endif
 
+  if exists('g:markdown_composer_address')
+    call extend(l:args, ['--address', g:markdown_composer_address])
+  endif
+
+  if exists('g:markdown_composer_port')
+    call extend(l:args, ['--port', g:markdown_composer_port])
+  endif
+
   for l:css in get(g:, 'markdown_composer_custom_css', [])
     call extend(l:args, ['--custom-css', l:css])
   endfor

--- a/doc/markdown-composer.txt
+++ b/doc/markdown-composer.txt
@@ -71,11 +71,21 @@ g:markdown_composer_autostart           *g:markdown_composer_autostart*
 g:markdown_composer_custom_css          *g:markdown_composer_custom_css*
             A list of custom CSS URIs that should be loaded instead of the
             GitHub styles.
-            
+
             You may provide local paths and URLs, but they must be absolute
             and prefixed with a scheme ('file:///home/euclio/markdown.css')
 
             Default: []
+
+g:markdown_composer_address          *g:markdown_composer_address*
+            The address which the server will listen on.
+
+            Default: localhost
+
+g:markdown_composer_port          *g:markdown_composer_port*
+            The port number which the server will listen on.
+
+            Default: 0 (ephemeral)
 
 COMMANDS                                *markdown-composer-commands*
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@
 use std::default::Default;
 use std::error::Error;
 use std::fs;
-use std::io::prelude::*;
 use std::io;
+use std::io::prelude::*;
 use std::mem;
 use std::process::Command;
 
@@ -134,11 +134,9 @@ fn read_rpc(
                 let markdown = mem::replace(&mut rpc.params[0], String::new());
                 server.send(markdown)
             }
-            "open_browser" => {
-                match browser {
-                    Some(browser) => server.open_specific_browser(Command::new(browser)),
-                    None => server.open_browser(),
-                }
+            "open_browser" => match browser {
+                Some(browser) => server.open_specific_browser(Command::new(browser)),
+                None => server.open_browser(),
             },
             "chdir" => {
                 let cwd = &rpc.params[0];
@@ -164,9 +162,11 @@ fn run() -> Result<(), Box<dyn Error>> {
         .author(crate_authors!())
         .version(crate_version!())
         .about(ABOUT)
-        .arg(Arg::with_name("no-auto-open").long("no-auto-open").help(
-            "Don't open the web browser automatically.",
-        ))
+        .arg(
+            Arg::with_name("no-auto-open")
+                .long("no-auto-open")
+                .help("Don't open the web browser automatically."),
+        )
         .arg(
             Arg::with_name("browser")
                 .long("browser")
@@ -210,17 +210,32 @@ fn run() -> Result<(), Box<dyn Error>> {
         .arg(
             Arg::with_name("external-renderer")
                 .long("external-renderer")
-                .help(
-                    "An external process that should be used for rendering markdown.",
-                )
+                .help("An external process that should be used for rendering markdown.")
                 .takes_value(true),
         )
-        .arg(Arg::with_name("markdown-file").help(
-            "A markdown file that should be rendered by the server on startup.",
-        ))
+        .arg(
+            Arg::with_name("markdown-file")
+                .help("A markdown file that should be rendered by the server on startup."),
+        )
+        .arg(
+            Arg::with_name("address")
+                .long("address")
+                .help("The address that this server will listen on. The default value is `localhost`.")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("port")
+                .long("port")
+                .help("The port number that this server will listen on. The default value is `0 (ephemeral)`.")
+                .takes_value(true),
+        )
         .get_matches();
 
-    let mut server = Server::bind("localhost:0")?;
+    let mut server = Server::bind(format!(
+        "{}:{}",
+        matches.value_of("address").unwrap_or("localhost"),
+        matches.value_of("port").unwrap_or("0")
+    ))?;
 
     if let Some(external_renderer) = matches.value_of("external-renderer") {
         let words = Shlex::new(external_renderer).collect::<Vec<_>>();


### PR DESCRIPTION
Add options to fix address and port number which the server will listen on:
- `g:markdown_composer_address`
    - default: `localhost`
- `g:markdown_composer_port`
    - default: `0`

This implements #24. (and conflicts with #85 regarding the port number.)

### Motivation

I'm always developing anything on the VM (VirtualBox) via ssh from the host OS. So, I'd like to fix the port number which the composer server will listen on to connect it by using ssh + port forwarding. And also I'd like to make the server be able to listen on `0.0.0.0` to connect from the host OS.