### PR TITLE
Fixed typo in vimscript

### DIFF
--- a/after/ftplugin/markdown/composer.vim
+++ b/after/ftplugin/markdown/composer.vim
@@ -14,10 +14,10 @@ function! s:startServer()
   endif
 
   let l:binary = get(
-    g:,
-    'markdown_composer_binary',
-    s:plugin_root . '/target/release/markdown-composer'
-  )
+			  \g:,
+			  \'markdown_composer_binary',
+			  \s:plugin_root . '/target/release/markdown-composer'
+			  \)
 
   let l:args = [l:binary]
 


### PR DESCRIPTION
This fixes a simple issue in the vimscript in the `composer.vim` file that was causing errors when calling the `:ComposerStart` function. 